### PR TITLE
Autoapproval (#136)

### DIFF
--- a/manager/src/main/java/fk/retail/ip/manager/ManagerApplication.java
+++ b/manager/src/main/java/fk/retail/ip/manager/ManagerApplication.java
@@ -40,6 +40,10 @@ public class ManagerApplication extends Application<ManagerConfiguration> {
         Properties jpaProperties = new Properties();
         jpaProperties.put(JpaWithSpringModule.HIBERNATE_EJB_NAMING_STRATEGY,
                 "fk.retail.ip.manager.config.AnnotationRespectfulNamingStrategy");
+        jpaProperties.put("hibernate.jdbc.batch_size",30);
+        jpaProperties.put("hibernate.order_inserts", "true");
+        jpaProperties.put("hibernate.order_updates", "true");
+        jpaProperties.put("hibernate.jdbc.batch_versioned_data", "true");
         this.guiceBundle = GuiceBundle.<ManagerConfiguration>newBuilder()
                 .setConfigClass(ManagerConfiguration.class)
                 .addModule(new ManagerModule())

--- a/requirement/src/main/java/fk/retail/ip/requirement/config/RequirementModule.java
+++ b/requirement/src/main/java/fk/retail/ip/requirement/config/RequirementModule.java
@@ -13,6 +13,7 @@ import fk.retail.ip.requirement.internal.repository.JPALastAppSupplierRepository
 import fk.retail.ip.requirement.internal.repository.JPAOpenRequirementAndPurchaseOrderRepository;
 import fk.retail.ip.requirement.internal.repository.JPAPolicyRepository;
 import fk.retail.ip.requirement.internal.repository.JPAProductInfoRepository;
+import fk.retail.ip.requirement.internal.repository.JPARequirementApprovalTransitionRepository;
 import fk.retail.ip.requirement.internal.repository.JPARequirementRepository;
 import fk.retail.ip.requirement.internal.repository.JPAWarehouseInventoryRepository;
 import fk.retail.ip.requirement.internal.repository.JPAWarehouseRepository;
@@ -26,6 +27,7 @@ import fk.retail.ip.requirement.internal.repository.ProcPurchaseOrderRepositoryI
 import fk.retail.ip.requirement.internal.repository.ProductInfoRepository;
 import fk.retail.ip.requirement.internal.repository.ProjectionRepository;
 import fk.retail.ip.requirement.internal.repository.ProjectionRepositoryImpl;
+import fk.retail.ip.requirement.internal.repository.RequirementApprovalTransitionRepository;
 import fk.retail.ip.requirement.internal.repository.RequirementRepository;
 import fk.retail.ip.requirement.internal.repository.WarehouseInventoryRepository;
 import fk.retail.ip.requirement.internal.repository.WarehouseRepository;
@@ -59,6 +61,7 @@ public class RequirementModule extends AbstractModule {
         bind(ForecastRepository.class).to(JPAForecastRepository.class);
         bind(ProcPurchaseOrderRepository.class).to(ProcPurchaseOrderRepositoryImpl.class);
         bind(WarehouseSupplierSlaRepository.class).to(WarehouseSupplierSlaRepositoryImpl.class);
+        bind(RequirementApprovalTransitionRepository.class).to(JPARequirementApprovalTransitionRepository.class);
         //TODO:remove
         bind(ProjectionRepository.class).to(ProjectionRepositoryImpl.class);
 

--- a/requirement/src/main/java/fk/retail/ip/requirement/internal/Constants.java
+++ b/requirement/src/main/java/fk/retail/ip/requirement/internal/Constants.java
@@ -1,11 +1,6 @@
 package fk.retail.ip.requirement.internal;
 
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.util.Optional;
-import java.util.Properties;
 import com.google.common.collect.Sets;
 import java.util.Set;
 
@@ -18,6 +13,7 @@ public interface Constants {
     int DAYS_IN_WEEK = 7;
     int WEEKS_OF_FORECAST = 15;
     double MIN_CASE_SIZE = 1D;
+    long DEFAULT_TRANSITION_GROUP = 1;
     String MAX_COVERAGE_KEY = "max_coverage";
     String CASE_SIZE_KEY = "case_size";
     Set<String> INTRANSIT_REQUEST_STATUSES = Sets.newHashSet("in-process", "dispatched", "requested");

--- a/requirement/src/main/java/fk/retail/ip/requirement/internal/entities/Requirement.java
+++ b/requirement/src/main/java/fk/retail/ip/requirement/internal/entities/Requirement.java
@@ -5,7 +5,6 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
 import javax.xml.bind.annotation.XmlRootElement;
 
 /**
@@ -113,5 +112,9 @@ public class Requirement extends AbstractEntity {
         projectionId = other.projectionId;
         panIndiaQuantity = other.panIndiaQuantity;
         sslId = other.sslId;
+    }
+
+    public long getGroup() {
+        return this.requirementSnapshot.getGroup().getId();
     }
 }

--- a/requirement/src/main/java/fk/retail/ip/requirement/internal/entities/RequirementApprovalTransition.java
+++ b/requirement/src/main/java/fk/retail/ip/requirement/internal/entities/RequirementApprovalTransition.java
@@ -1,0 +1,18 @@
+package fk.retail.ip.requirement.internal.entities;
+
+import javax.persistence.Entity;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Created by nidhigupta.m on 24/03/17.
+ */
+@Entity
+@Data
+@NoArgsConstructor
+public class RequirementApprovalTransition extends ReadOnlyEntity {
+    long groupId;
+    String fromState;
+    String toState;
+    boolean forward;
+}

--- a/requirement/src/main/java/fk/retail/ip/requirement/internal/enums/RequirementApprovalAction.java
+++ b/requirement/src/main/java/fk/retail/ip/requirement/internal/enums/RequirementApprovalAction.java
@@ -1,0 +1,28 @@
+package fk.retail.ip.requirement.internal.enums;
+
+import lombok.Getter;
+
+/**
+ * Created by nidhigupta.m on 24/03/17.
+ */
+
+@Getter
+public enum RequirementApprovalAction {
+    verify(true),
+    approve(true),
+    bd_approve(true),
+    bizfin_approve(true),
+    ipc_finalize(true),
+    cancel_verify(false),
+    cancel_approve(false),
+    cancel_bd_approve(false),
+    cancel_bizfin_approve(false),
+    cancel_ipc_finalize(false);
+
+    boolean isForward;
+
+    RequirementApprovalAction(boolean isForward) {
+        this.isForward = isForward;
+    }
+
+}

--- a/requirement/src/main/java/fk/retail/ip/requirement/internal/repository/JPARequirementApprovalTransitionRepository.java
+++ b/requirement/src/main/java/fk/retail/ip/requirement/internal/repository/JPARequirementApprovalTransitionRepository.java
@@ -1,0 +1,32 @@
+package fk.retail.ip.requirement.internal.repository;
+
+import com.google.inject.Inject;
+import fk.retail.ip.requirement.internal.entities.RequirementApprovalTransition;
+import fk.sp.common.extensions.jpa.SimpleJpaGenericRepository;
+import java.util.List;
+import javax.inject.Provider;
+import javax.persistence.EntityManager;
+import javax.persistence.TypedQuery;
+
+/**
+ * Created by nidhigupta.m on 24/03/17.
+ */
+public class JPARequirementApprovalTransitionRepository extends SimpleJpaGenericRepository<RequirementApprovalTransition, Long>
+        implements RequirementApprovalTransitionRepository {
+
+    @Inject
+    public JPARequirementApprovalTransitionRepository(Provider<EntityManager> entityManagerProvider) {
+        super(entityManagerProvider);
+    }
+
+
+    @Override
+    public List<RequirementApprovalTransition> getApprovalTransition(String fromState, boolean forward) {
+        TypedQuery<RequirementApprovalTransition> query = getEntityManager().
+                createNamedQuery("RequirementApprovalTransition.getApprovalStateTransition",RequirementApprovalTransition.class);
+        query.setParameter("fromState", fromState);
+        query.setParameter("forward", forward);
+        return query.getResultList();
+
+    }
+}

--- a/requirement/src/main/java/fk/retail/ip/requirement/internal/repository/RequirementApprovalTransitionRepository.java
+++ b/requirement/src/main/java/fk/retail/ip/requirement/internal/repository/RequirementApprovalTransitionRepository.java
@@ -1,0 +1,14 @@
+package fk.retail.ip.requirement.internal.repository;
+
+import fk.retail.ip.requirement.internal.entities.RequirementApprovalTransition;
+import fk.sp.common.extensions.jpa.JpaGenericRepository;
+import java.util.List;
+
+/**
+ * Created by nidhigupta.m on 24/03/17.
+ */
+public interface RequirementApprovalTransitionRepository extends JpaGenericRepository<RequirementApprovalTransition, Long> {
+
+
+    List<RequirementApprovalTransition> getApprovalTransition(String fromState, boolean forward);
+}

--- a/requirement/src/main/java/fk/retail/ip/requirement/internal/repository/RequirementRepository.java
+++ b/requirement/src/main/java/fk/retail/ip/requirement/internal/repository/RequirementRepository.java
@@ -4,6 +4,7 @@ import fk.retail.ip.requirement.internal.entities.Requirement;
 import fk.sp.common.extensions.jpa.JpaGenericRepository;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Created by nidhigupta.m on 15/02/17.
@@ -13,6 +14,7 @@ public interface RequirementRepository extends JpaGenericRepository<Requirement,
     int PAGE_SIZE = 1000;
 
     List<Requirement> findRequirementByIds(List<Long> requirementIds);
+
 
     List<Long> findProjectionIds(List<String> fsns, String state);
 
@@ -27,5 +29,7 @@ public interface RequirementRepository extends JpaGenericRepository<Requirement,
     List<Requirement> findRequirements(List<Long> projectionIds, String requirementState,List<String> fsns);
 
     List<Requirement> find(Collection<String> fsns, boolean enabled);
-    int updateProjection(Collection<Long> projectionIds, String toState);
+
+    //TODO: legacy code
+    void updateProjections(List<Requirement> requirements, Map<Long, String> groupToTargetState);
 }

--- a/requirement/src/main/java/fk/retail/ip/requirement/service/ApprovalService.java
+++ b/requirement/src/main/java/fk/retail/ip/requirement/service/ApprovalService.java
@@ -1,56 +1,37 @@
 package fk.retail.ip.requirement.service;
 
-import com.google.common.collect.HashBasedTable;
-import com.google.common.collect.Table;
-import com.google.common.io.CharStreams;
-import com.google.inject.Inject;
-import com.google.inject.name.Named;
+import fk.retail.ip.requirement.internal.Constants;
 import fk.retail.ip.requirement.internal.entities.AbstractEntity;
 import fk.retail.ip.requirement.internal.entities.Requirement;
+import fk.retail.ip.requirement.internal.entities.RequirementApprovalTransition;
 import fk.retail.ip.requirement.internal.enums.RequirementApprovalState;
+import fk.retail.ip.requirement.internal.repository.RequirementApprovalTransitionRepository;
 import fk.retail.ip.requirement.internal.repository.RequirementRepository;
-import java.io.InputStreamReader;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import org.json.JSONObject;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  *
  * @author Pragalathan M<pragalathan.m@flipkart.com>
  */
+
+@Slf4j
 public class ApprovalService<E extends AbstractEntity> {
 
-    private JSONObject actions;
-
-    @Inject
-    public ApprovalService(@Named("actionConfiguration") String actionConfiguration) {
-        try (InputStreamReader reader = new InputStreamReader(getClass().getResourceAsStream(actionConfiguration))) {
-            actions = new JSONObject(CharStreams.toString(reader));
-        } catch (Exception ex) {
-            throw new RuntimeException("Error in reading config file", ex);
-        }
-    }
-
-    public String getTargetState(String action) {
-        return actions.getJSONObject(action).getString("nextState");
-    }
-
     public void changeState(List<E> items,
-            String userId,
-            String action,
-            Function<E, String> getter,
-            StageChangeAction<E>... actionListeners) {
-        JSONObject stateMachine = actions.getJSONObject(action);
-        String fromState = stateMachine.getString("currentState");
-        String toState = stateMachine.getString("nextState");
-        boolean forward = stateMachine.getBoolean("isForward");
+                            String fromState,
+                            String userId,
+                            boolean forward,
+                            Function<E, String> getter,
+                            StageChangeAction<E>... actionListeners) {
         validate(items, fromState, getter);
         for (StageChangeAction<E> consumer : actionListeners) {
-            consumer.execute(userId, fromState, toState, forward, items);
+            consumer.execute(userId, fromState, forward, items);
         }
     }
 
@@ -63,88 +44,84 @@ public class ApprovalService<E extends AbstractEntity> {
         }
     }
 
-    public static interface StageChangeAction<E extends AbstractEntity> {
+    public interface StageChangeAction<E extends AbstractEntity> {
 
         void execute(String userId,
-                String fromState,
-                String toState,
-                boolean forward,
-                List<E> entity);
+                     String fromState,
+                     boolean forward,
+                     List<E> entity);
     }
 
     public static class CopyOnStateChangeAction implements StageChangeAction<Requirement> {
 
-        private RequirementRepository repository;
+        private RequirementRepository requirementRepository;
+        private RequirementApprovalTransitionRepository requirementApprovalStateTransitionRepository;
 
-        public CopyOnStateChangeAction(RequirementRepository requirementRepository) {
-            this.repository = requirementRepository;
+        public CopyOnStateChangeAction(RequirementRepository requirementRepository, RequirementApprovalTransitionRepository requirementApprovalStateTransitionRepository) {
+            this.requirementRepository = requirementRepository;
+            this.requirementApprovalStateTransitionRepository = requirementApprovalStateTransitionRepository;
         }
+
 
         @Override
-        public void execute(String userId, String fromState, String toState, boolean forward, List<Requirement> entities) {
-            Map<String, List<Requirement>> fsnToRequirements = entities.stream().collect(Collectors.groupingBy(Requirement::getFsn));
-            List<Requirement> toEntities = repository.findEnabledRequirementsByStateFsn(toState, fsnToRequirements.keySet());
-            Table<String, String, Requirement> cdoStateEntityMap = getCDOEntityMap(toState,  fsnToRequirements.keySet());
-            boolean isIPCReviewState = RequirementApprovalState.IPC_REVIEW.toString().equals(toState);
-            fsnToRequirements.keySet().stream().forEach((fsn) -> {
-                fsnToRequirements.get(fsn).stream().forEach((entity) -> {
-                    Optional<Requirement> toStateEntity = toEntities.stream().filter(e -> e.getWarehouse().equals(entity.getWarehouse()) && e.getFsn().equals(entity.getFsn())).findFirst();
-                    if (forward) {
-                        if (toStateEntity.isPresent()) {
-                            toStateEntity.get().setQuantity(entity.getQuantity());
-                            if(isIPCReviewState) {
-                                toStateEntity.get().setQuantity(cdoStateEntityMap.get(entity.getFsn(), entity.getWarehouse()).getQuantity());
-                            }
-                            toStateEntity.get().setSupplier(entity.getSupplier());
-                            toStateEntity.get().setApp(entity.getApp());
-                            toStateEntity.get().setSla(entity.getSla());
-                            toStateEntity.get().setPreviousStateId(entity.getId());
-                            toStateEntity.get().setCreatedBy(userId);
-                            toStateEntity.get().setCurrent(true);
-                            entity.setCurrent(false);
-                        } else {
-                            Requirement newEntity = new Requirement(entity);
-                            if(isIPCReviewState) {
-                                newEntity.setQuantity(cdoStateEntityMap.get(entity.getFsn(), entity.getWarehouse()).getQuantity());
-                            }
-                            newEntity.setState(toState);
-                            newEntity.setCreatedBy(userId);
-                            newEntity.setPreviousStateId(entity.getId());
-                            newEntity.setCurrent(true);
-                            repository.persist(newEntity);
-                            entity.setCurrent(false);
-                        }
-                    } else {
-                        toStateEntity.ifPresent(e -> { // this will always be present
-                            e.setCurrent(true);
-                            entity.setCurrent(false);
-                        });
-                    }
-                });
-            });
-        }
-
-        private Table<String,String,Requirement> getCDOEntityMap(String toState, Set<String> fsns) {
-            Table<String, String, Requirement> cdoStateRequirementMap = HashBasedTable.create();
-            boolean isIPCReviewState = RequirementApprovalState.IPC_REVIEW.toString().equals(toState);
-            if (isIPCReviewState) {
+        public void execute(String userId, String fromState, boolean forward, List<Requirement> requirements) {
+            Map<Long, String> groupToTargetState = getGroupToTargetStateMap(fromState, forward);
+            log.info("Constructed map for group to Target state " + groupToTargetState);
+            Map<Long, String> requirementToTargetStateMap = getRequirementToTargetStateMap(groupToTargetState, requirements);
+            Set<String> fsns = requirements.stream().map(Requirement::getFsn).collect(Collectors.toSet());
+            List<Requirement> allEnabledRequirements = requirementRepository.find(fsns, true);
+            requirements.stream().forEach((requirement) -> {
+                String toState = requirementToTargetStateMap.get(requirement.getId());
+                boolean isIPCReviewState = RequirementApprovalState.IPC_REVIEW.toString().equals(toState);
                 String cdoState = RequirementApprovalState.CDO_REVIEW.toString();
-                List<Requirement> cdoReviewEntities = repository.findEnabledRequirementsByStateFsn(cdoState, fsns);
-                cdoReviewEntities.forEach((entity) -> {
-                    cdoStateRequirementMap.put(entity.getFsn(), entity.getWarehouse(), entity);
-                });
-            }
-            return cdoStateRequirementMap ;
-        }
-
-        private Table<String,String,Requirement> getToStateEntity(String toState, Set<String> fsns) {
-            Table<String, String, Requirement> toStateRequirementMap = HashBasedTable.create();
-            List<Requirement> toStateEntities = repository.findEnabledRequirementsByStateFsn(toState, fsns);
-            toStateEntities.forEach((entity) -> {
-                toStateRequirementMap.put(entity.getFsn(), entity.getWarehouse(), entity);
+                Optional<Requirement> toStateEntity = allEnabledRequirements.stream().filter(e -> e.getFsn().equals(requirement.getFsn()) && e.getWarehouse().equals(requirement.getWarehouse()) && e.getState().equals(toState)).findFirst();
+                if (forward) {
+                    if (toStateEntity.isPresent()) {
+                        toStateEntity.get().setQuantity(requirement.getQuantity());
+                        if (isIPCReviewState) {
+                            Optional<Requirement> cdoStateEntity = allEnabledRequirements.stream().filter(e -> e.getFsn().equals(requirement.getFsn()) && e.getWarehouse().equals(requirement.getWarehouse()) && e.getState().equals(cdoState)).findFirst();
+                            toStateEntity.get().setQuantity(cdoStateEntity.get().getQuantity());
+                        }
+                        toStateEntity.get().setSupplier(requirement.getSupplier());
+                        toStateEntity.get().setApp(requirement.getApp());
+                        toStateEntity.get().setSla(requirement.getSla());
+                        toStateEntity.get().setPreviousStateId(requirement.getId());
+                        toStateEntity.get().setCreatedBy(userId);
+                        toStateEntity.get().setCurrent(true);
+                        requirement.setCurrent(false);
+                    } else {
+                        Requirement newEntity = new Requirement(requirement);
+                        if (isIPCReviewState) {
+                            Optional<Requirement> cdoStateEntity = allEnabledRequirements.stream().filter(e -> e.getFsn().equals(requirement.getFsn()) && e.getWarehouse().equals(requirement.getWarehouse()) && e.getState().equals(cdoState)).findFirst();
+                            newEntity.setQuantity(cdoStateEntity.get().getQuantity());
+                        }
+                        newEntity.setState(toState);
+                        newEntity.setCreatedBy(userId);
+                        newEntity.setPreviousStateId(requirement.getId());
+                        newEntity.setCurrent(true);
+                        requirementRepository.persist(newEntity);
+                        requirement.setCurrent(false);
+                    }
+                } else {
+                    toStateEntity.ifPresent(e -> { // this will always be present
+                        e.setCurrent(true);
+                        requirement.setCurrent(false);
+                    });
+                }
             });
-
-            return toStateRequirementMap ;
+            log.info("Updating Projections tables for Requirements");
+            requirementRepository.updateProjections(requirements, groupToTargetState);
         }
+
+
+        private Map<Long, String> getGroupToTargetStateMap(String fromState, boolean forward) {
+            List<RequirementApprovalTransition> transitionList = requirementApprovalStateTransitionRepository.getApprovalTransition(fromState, forward);
+            return transitionList.stream().collect(Collectors.toMap(RequirementApprovalTransition::getGroupId, RequirementApprovalTransition::getToState));
+        }
+
+        private Map<Long,String> getRequirementToTargetStateMap(Map<Long, String> groupToTargetState, List<Requirement> requirements) {
+            return requirements.stream().collect(Collectors.toMap(requirement -> requirement.getId(), requirement -> groupToTargetState.get(requirement.getGroup())!= null ? groupToTargetState.get(requirement.getGroup()):groupToTargetState.get(Constants.DEFAULT_TRANSITION_GROUP)));
+        }
+
     }
 }

--- a/requirement/src/main/java/fk/retail/ip/requirement/service/RequirementService.java
+++ b/requirement/src/main/java/fk/retail/ip/requirement/service/RequirementService.java
@@ -12,7 +12,9 @@ import fk.retail.ip.requirement.internal.command.SearchCommand;
 import fk.retail.ip.requirement.internal.command.SearchFilterCommand;
 import fk.retail.ip.requirement.internal.entities.Requirement;
 import fk.retail.ip.requirement.internal.enums.OverrideStatus;
+import fk.retail.ip.requirement.internal.enums.RequirementApprovalAction;
 import fk.retail.ip.requirement.internal.factory.RequirementStateFactory;
+import fk.retail.ip.requirement.internal.repository.RequirementApprovalTransitionRepository;
 import fk.retail.ip.requirement.internal.repository.RequirementRepository;
 import fk.retail.ip.requirement.internal.states.RequirementState;
 import fk.retail.ip.requirement.model.*;
@@ -23,7 +25,10 @@ import org.json.JSONException;
 import javax.ws.rs.core.StreamingOutput;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -36,6 +41,7 @@ import java.util.stream.Collectors;
 public class RequirementService {
 
     private final RequirementRepository requirementRepository;
+    private final RequirementApprovalTransitionRepository requirementApprovalStateTransitionRepository;
     private final RequirementStateFactory requirementStateFactory;
     private final ApprovalService approvalService;
     private final Provider<CalculateRequirementCommand> calculateRequirementCommandProvider;
@@ -46,11 +52,13 @@ public class RequirementService {
     @Inject
     public RequirementService(RequirementRepository requirementRepository, RequirementStateFactory requirementStateFactory,
                               ApprovalService approvalService, Provider<CalculateRequirementCommand> calculateRequirementCommandProvider,
+                              RequirementApprovalTransitionRepository requirementApprovalStateTransitionRepository,
                               SearchFilterCommand searchFilterCommand, Provider<SearchCommand> searchCommandProvider) {
         this.requirementRepository = requirementRepository;
         this.requirementStateFactory = requirementStateFactory;
         this.approvalService = approvalService;
         this.calculateRequirementCommandProvider = calculateRequirementCommandProvider;
+        this.requirementApprovalStateTransitionRepository = requirementApprovalStateTransitionRepository;
         this.searchFilterCommand = searchFilterCommand;
         this.searchCommandProvider = searchCommandProvider;
     }
@@ -136,21 +144,19 @@ public class RequirementService {
     }
 
     public String changeState(RequirementApprovalRequest request) throws JSONException {
-        String action = request.getFilters().get("projection_action").toString();
-        Function<Requirement, String> getter = Requirement::getState;
-        List<Requirement> requirements;
+        log.info("Approval request received for " + request);
+        RequirementApprovalAction action = RequirementApprovalAction.valueOf(request.getFilters().get("projection_action").toString());
+        boolean forward = action.isForward();
         List<Long> ids = (List<Long>) request.getFilters().get("id");
         String state = (String) request.getFilters().get("state");
-        Set<Long> projectionIds = new HashSet<>();
+        Function<Requirement, String> getter = Requirement::getState;
+        List<Requirement> requirements;
         List<String> fsns = searchFilterCommand.getSearchFilterFsns(request.getFilters());
         requirements = requirementRepository.findRequirements(ids, state, fsns);
         log.info("Change state Request for {} number of requirements", requirements.size());
-        requirements.stream().forEach(e -> projectionIds.add(e.getProjectionId()));
-        approvalService.changeState(requirements, "dummyUser", action, getter, new ApprovalService.CopyOnStateChangeAction(requirementRepository));
+        approvalService.changeState(requirements, state, "dummyUser", forward, getter, new ApprovalService.CopyOnStateChangeAction(requirementRepository, requirementApprovalStateTransitionRepository ));
         log.info("State changed for {} number of requirements", requirements.size());
-        requirementRepository.updateProjection(projectionIds, approvalService.getTargetState(action));
-        log.info("Projections table updated for Requirements");
-        return "{\"msg\":\"Moved " + projectionIds.size() + " projections to new state.\"}";
+        return "{\"msg\":\"Moved " + requirements.size() + " requirements to new state.\"}";
     }
 
     public SearchResponse.GroupedResponse search(RequirementSearchRequest request) throws JSONException {
@@ -182,6 +188,8 @@ public class RequirementService {
         log.info("Got Search Response for Requirement");
         return groupedResponse;
     }
+
+
 
 
     public void calculateRequirement(CalculateRequirementRequest calculateRequirementRequest) {

--- a/requirement/src/main/resources/fk/retail/ip/requirement/queries.hbm.xml
+++ b/requirement/src/main/resources/fk/retail/ip/requirement/queries.hbm.xml
@@ -380,4 +380,19 @@
         </query>
     </named-query>
 
+    <named-query name="RequirementApprovalTransition.getApprovalStateTransition">
+        <query>
+            <![CDATA[
+            SELECT t
+            FROM RequirementApprovalTransition t
+            WHERE
+                t.fromState = :fromState and
+                t.forward = :forward
+                  ]]>
+        </query>
+    </named-query>
+
+
+
+
 </entity-mappings>

--- a/requirement/src/main/resources/migrations/2017_02_20_alter_old_schema.sql
+++ b/requirement/src/main/resources/migrations/2017_02_20_alter_old_schema.sql
@@ -59,3 +59,16 @@ alter table ip_groups add column is_enabled TINYINT(1) NOT NULL DEFAULT 0;
 update ip_groups set is_enabled= 1 where tag = "rp_planning";
 
 alter table `INTRANSIT` add column `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+
+
+CREATE TABLE `requirement_approval_state_transition` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `group_id` int(11) NOT NULL,
+  `from_state` varchar(20) NOT NULL DEFAULT '',
+  `to_state` varchar(20) NOT NULL DEFAULT '',
+  `action` varchar(20) NOT NULL DEFAULT '',
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `group_fromstate_action` (`group_id`,`from_state`,`action`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/requirement/src/test/java/fk/retail/ip/requirement/internal/repository/RequirementApprovalTransitionRepositoryTest.java
+++ b/requirement/src/test/java/fk/retail/ip/requirement/internal/repository/RequirementApprovalTransitionRepositoryTest.java
@@ -1,0 +1,36 @@
+package fk.retail.ip.requirement.internal.repository;
+
+import com.google.inject.Inject;
+import fk.retail.ip.requirement.config.TestDbModule;
+import fk.retail.ip.requirement.internal.entities.RequirementApprovalTransition;
+import fk.sp.common.extensions.jpa.TransactionalJpaRepositoryTest;
+import java.util.List;
+import org.jukito.JukitoRunner;
+import org.jukito.UseModules;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Created by nidhigupta.m on 27/03/17.
+ */
+
+@RunWith(JukitoRunner.class)
+@UseModules(TestDbModule.class)
+public class RequirementApprovalTransitionRepositoryTest extends TransactionalJpaRepositoryTest {
+
+    @Inject
+    RequirementApprovalTransitionRepository requirementApprovalTransitionRepository;
+
+    @Test
+    public void testGetApprovalTransition() {
+
+        RequirementApprovalTransition requirementApprovalTransition = TestHelper.getRequirementApprovalTransition(1l, "proposed", "ipc_review", true);
+        requirementApprovalTransitionRepository.persist(requirementApprovalTransition);
+        List<RequirementApprovalTransition> requirementApprovalTransitions1 = requirementApprovalTransitionRepository.findAll();
+        System.out.println("all size is " +requirementApprovalTransitions1 );
+        List<RequirementApprovalTransition> requirementApprovalTransitions = requirementApprovalTransitionRepository.getApprovalTransition("proposed", true);
+        Assert.assertEquals(1,requirementApprovalTransitions.size());
+        Assert.assertEquals("ipc_review", requirementApprovalTransitions.get(0).getToState());
+    }
+}

--- a/requirement/src/test/java/fk/retail/ip/requirement/internal/repository/TestHelper.java
+++ b/requirement/src/test/java/fk/retail/ip/requirement/internal/repository/TestHelper.java
@@ -12,6 +12,7 @@ import fk.retail.ip.requirement.internal.entities.OpenRequirementAndPurchaseOrde
 import fk.retail.ip.requirement.internal.entities.Policy;
 import fk.retail.ip.requirement.internal.entities.ProductInfo;
 import fk.retail.ip.requirement.internal.entities.Requirement;
+import fk.retail.ip.requirement.internal.entities.RequirementApprovalTransition;
 import fk.retail.ip.requirement.internal.entities.RequirementSnapshot;
 import fk.retail.ip.requirement.internal.entities.Warehouse;
 import fk.retail.ip.requirement.internal.entities.WarehouseSupplierSla;
@@ -49,6 +50,14 @@ public class TestHelper {
         groupFsn.setGroup(group);
         groupFsn.setCreatedAt(new Date());
         return groupFsn;
+    }
+
+    public static Group getGroup(String groupName) {
+        Group group = new Group();
+        group.setName(groupName);
+        group.setEnabled(true);
+        group.setCreatedAt(new Date());
+        return group;
     }
 
     public static Group getEnabledGroup(String name) {
@@ -89,6 +98,32 @@ public class TestHelper {
         fsnBand.setPvBand(3);
         fsnBand.setTimeFrame(timeFrame);
         return fsnBand;
+    }
+
+    public static RequirementApprovalTransition getRequirementApprovalTransition(long groupId, String fromState, String toState, boolean forward) {
+        RequirementApprovalTransition requirementApprovalTransition = new RequirementApprovalTransition();
+        requirementApprovalTransition.setGroupId(groupId);
+        requirementApprovalTransition.setFromState(fromState);
+        requirementApprovalTransition.setToState(toState);
+        requirementApprovalTransition.setForward(forward);
+        return requirementApprovalTransition;
+    }
+
+
+    public static List<RequirementApprovalTransition> getRequirementApprovalTransitionList(long groupId, String fromState, String toState, boolean forward) {
+        List<RequirementApprovalTransition> requirementApprovalTransitionList = Lists.newArrayList();
+        RequirementApprovalTransition requirementApprovalTransition = new RequirementApprovalTransition();
+        requirementApprovalTransition.setGroupId(groupId);
+        requirementApprovalTransition.setFromState(fromState);
+        requirementApprovalTransition.setToState(toState);
+        requirementApprovalTransition.setForward(forward);
+        requirementApprovalTransitionList.add(requirementApprovalTransition);
+        requirementApprovalTransition.setGroupId(1l);
+        requirementApprovalTransition.setFromState(fromState);
+        requirementApprovalTransition.setToState(toState);
+        requirementApprovalTransition.setForward(forward);
+        requirementApprovalTransitionList.add(requirementApprovalTransition);
+        return requirementApprovalTransitionList;
     }
 
     public static LastAppSupplier getLastAppSupplier(String fsn, String wh, String supplier, int app) {

--- a/requirement/src/test/java/fk/retail/ip/requirement/service/ApprovalServiceTest.java
+++ b/requirement/src/test/java/fk/retail/ip/requirement/service/ApprovalServiceTest.java
@@ -1,25 +1,32 @@
 package fk.retail.ip.requirement.service;
 
-import com.google.inject.Inject;
 import fk.retail.ip.requirement.config.TestDbModule;
+import fk.retail.ip.requirement.internal.Constants;
+import fk.retail.ip.requirement.internal.entities.Group;
 import fk.retail.ip.requirement.internal.entities.Requirement;
+import fk.retail.ip.requirement.internal.entities.RequirementApprovalTransition;
+import fk.retail.ip.requirement.internal.entities.RequirementSnapshot;
 import fk.retail.ip.requirement.internal.enums.RequirementApprovalState;
+import fk.retail.ip.requirement.internal.repository.RequirementApprovalTransitionRepository;
 import fk.retail.ip.requirement.internal.repository.RequirementRepository;
+import fk.retail.ip.requirement.internal.repository.TestHelper;
 import fk.sp.common.extensions.jpa.TransactionalJpaRepositoryTest;
-import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.function.Function;
-import javax.inject.Provider;
-import javax.persistence.EntityManager;
-import javax.persistence.NoResultException;
 import org.jukito.JukitoRunner;
 import org.jukito.UseModules;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 
 /**
  * @author Pragalathan M<pragalathan.m@flipkart.com>
@@ -28,162 +35,127 @@ import org.junit.runner.RunWith;
 @UseModules(TestDbModule.class)
 public class ApprovalServiceTest extends TransactionalJpaRepositoryTest {
 
-    @Inject
+    @Mock
     private RequirementRepository requirementRepository;
 
-    @Inject
-    private Provider<EntityManager> entityManagerProvider;
+    @Mock
+    private RequirementApprovalTransitionRepository requirementApprovalStateTransitionRepository;
 
-    @Test
-    public void testProposedStateForwardFlow() {
-        testForwardFlow("proposed", "verified", "verify");
-    }
+    @InjectMocks
+    private ApprovalService approvalService;
 
-    @Test
-    public void testVerifiedStateForwardFlow() {
-        testForwardFlow("verified", "approved", "approve");
-    }
 
-    @Test
-    public void testApprovedStateForwardFlow() {
-        testForwardFlow("approved", "bd_approved", "bd_approve");
-    }
+    @Captor
+    private ArgumentCaptor<Requirement> captor;
 
-    @Test
-    public void testBdApprovedStateForwardFlow() {
-        testForwardFlow("bd_approved", "bizfin_approved", "bizfin_approve");
-    }
 
-    @Test
-    public void testBizFinApprovedStateForwardFlow() {
-        testForwardFlow("bizfin_approved", "ipc_finalized", "ipc_finalize");
-    }
-
-    public void testVerifiedStateBackwardFlow() {
-        testBackwardFlow("verified", "proposed", "cancel_verify");
-    }
-
-    @Test
-    public void testApprovedStateBackwardFlow() {
-        testBackwardFlow("approved", "verified", "cancel_approve");
-    }
-
-    @Test
-    public void testBdApprovedStateBackwardFlow() {
-        testBackwardFlow("bd_approved", "approved", "cancel_bd_approve");
-    }
-
-    @Test
-    public void testBizFinApprovedStateBackwardFlow() {
-        testBackwardFlow("bizfin_approved", "bd_approved", "cancel_bizfin_approve");
-    }
-
-    private void testForwardFlow(String fromState, String toState, String action) {
-        Requirement requirement = createRequirement(fromState);
-        Requirement cdoRequirement = createRequirement(RequirementApprovalState.CDO_REVIEW.toString());
-        ApprovalService service = new ApprovalService("/requirement-state-actions.json");
+    @Test(expected = IllegalStateException.class)
+    public void testApprovalFlowWithInvalidState() {
+        String fromState = "proposed";
+        Requirement requirement = createRequirement("verified", true);
         Function<Requirement, String> getter = Requirement::getState;
-        service.changeState(Arrays.asList(requirement), "userId", action, getter, new ApprovalService.CopyOnStateChangeAction(requirementRepository));
+        approvalService.changeState(Arrays.asList(requirement), fromState, "userId", true, getter, new ApprovalService.CopyOnStateChangeAction(requirementRepository, requirementApprovalStateTransitionRepository));
 
-        List<Requirement> results = requirementRepository.findEnabledRequirementsByStateFsn(toState, Arrays.asList(requirement.getFsn()));
-        Requirement actual = results.get(0);
-        Assert.assertEquals(toState, actual.getState());
-        Assert.assertTrue(actual.isCurrent());
-        Assert.assertTrue(actual.isEnabled());
-        Assert.assertEquals(actual.getPreviousStateId(), requirement.getId());
-
-        Assert.assertEquals(actual.getQuantity(), cdoRequirement.getQuantity(),0.01);
-
-        Assert.assertEquals(actual.getSla(), requirement.getSla());
-        Assert.assertEquals(actual.getSupplier(), requirement.getSupplier());
-        Assert.assertEquals(actual.getApp(), requirement.getApp());
-
-        Assert.assertFalse(requirement.isCurrent());
-        Assert.assertTrue(requirement.isEnabled());
     }
 
-    private void testBackwardFlow(String fromState, String toState, String action) {
-        createRequirement(toState); // create the previous state first
-        Requirement requirement = createRequirement(fromState);
-        ApprovalService service = new ApprovalService("/requirement-state-actions.json");
+    @Test
+    public void testApprovalForwardFlow() {
+        String fromState = RequirementApprovalState.PRE_PROPOSED.toString();
+        String toState =  RequirementApprovalState.CDO_REVIEW.toString();
+        boolean forward = true;
+        Requirement requirement = createRequirement(fromState, true);
         Function<Requirement, String> getter = Requirement::getState;
-        service.changeState(Arrays.asList(requirement), "userId", action, getter, new ApprovalService.CopyOnStateChangeAction(requirementRepository));
-
-        List<Requirement> results = requirementRepository.findEnabledRequirementsByStateFsn(toState, Arrays.asList(requirement.getFsn()));
-        Requirement actual = results.get(0);
-        Assert.assertEquals(toState, actual.getState());
-        Assert.assertTrue(actual.isCurrent());
-        Assert.assertTrue(actual.isEnabled());
-//        Assert.assertEquals(actual.getPreviousStateId(), requirement.getId());
-        Assert.assertEquals(actual.getQuantity(), requirement.getQuantity(), 0.01);
-        Assert.assertEquals(actual.getSla(), requirement.getSla());
-        Assert.assertEquals(actual.getSupplier(), requirement.getSupplier());
-        Assert.assertEquals(actual.getApp(), requirement.getApp());
-
-        Assert.assertFalse(requirement.isCurrent());
-        Assert.assertTrue(requirement.isEnabled());
+        RequirementApprovalTransition requirementApprovalTransition = TestHelper.getRequirementApprovalTransition(256, fromState, toState, forward);
+        Mockito.when(requirementApprovalStateTransitionRepository.getApprovalTransition(Mockito.anyString(), Mockito.eq(true))).thenReturn(Arrays.asList(requirementApprovalTransition));
+        Mockito.when(requirementRepository.find(Arrays.asList("fsn1"), true)).thenReturn(Arrays.asList(requirement));
+        Mockito.doNothing().when(requirementRepository).updateProjections(Mockito.anyList(), Mockito.anyMap());
+        approvalService.changeState(Arrays.asList(requirement), fromState, "userId", true, getter, new ApprovalService.CopyOnStateChangeAction(requirementRepository, requirementApprovalStateTransitionRepository));
+        Mockito.verify(requirementRepository).persist(captor.capture());
+        Assert.assertEquals(toState,captor.getValue().getState());
+        Assert.assertEquals(requirement.getId(), captor.getValue().getPreviousStateId());
+        Assert.assertEquals(true, captor.getValue().isCurrent());
+        Assert.assertEquals(false, requirement.isCurrent());
     }
 
-    private Requirement createRequirement(String state) {
+
+    @Test
+    public void testApprovalForwardFlowWithDefaultGroupTransition() {
+        String fromState = RequirementApprovalState.PRE_PROPOSED.toString();
+        String toState =  RequirementApprovalState.PROPOSED.toString();
+        boolean forward = true;
+        Requirement requirement = createRequirement(fromState, true);
+        Function<Requirement, String> getter = Requirement::getState;
+        RequirementApprovalTransition requirementApprovalTransition = TestHelper.getRequirementApprovalTransition(Constants.DEFAULT_TRANSITION_GROUP, fromState, toState, forward);
+        Mockito.when(requirementApprovalStateTransitionRepository.getApprovalTransition(Mockito.anyString(), Mockito.eq(true))).thenReturn(Arrays.asList(requirementApprovalTransition));
+        Mockito.when(requirementRepository.find(Arrays.asList("fsn1"), true)).thenReturn(Arrays.asList(requirement));
+        Mockito.doNothing().when(requirementRepository).updateProjections(Mockito.anyList(), Mockito.anyMap());
+        approvalService.changeState(Arrays.asList(requirement), fromState, "userId", true, getter, new ApprovalService.CopyOnStateChangeAction(requirementRepository, requirementApprovalStateTransitionRepository));
+        Mockito.verify(requirementRepository).persist(captor.capture());
+        Assert.assertEquals(toState,captor.getValue().getState());
+        Assert.assertEquals(requirement.getId(), captor.getValue().getPreviousStateId());
+        Assert.assertEquals(true, captor.getValue().isCurrent());
+        Assert.assertEquals(false, requirement.isCurrent());
+    }
+
+
+    @Test
+    public void testBackwardFlow() {
+        String fromState = RequirementApprovalState.PROPOSED.toString();
+        String toState =  RequirementApprovalState.PRE_PROPOSED.toString();
+        boolean forward = false;
+        Requirement requirement = createRequirement(fromState, true);
+        Function<Requirement, String> getter = Requirement::getState;
+        RequirementApprovalTransition requirementApprovalTransition = TestHelper.getRequirementApprovalTransition(Constants.DEFAULT_TRANSITION_GROUP, fromState, toState, forward);
+        Mockito.when(requirementApprovalStateTransitionRepository.getApprovalTransition(Mockito.anyString(), Mockito.eq(true))).thenReturn(Arrays.asList(requirementApprovalTransition));
+        Mockito.doNothing().when(requirementRepository).updateProjections(Mockito.anyList(), Mockito.anyMap());
+        List<Requirement> allEnabledRequirements = Arrays.asList(createRequirement(toState, false));
+        Mockito.when(requirementRepository.find(Arrays.asList("fsn1"), true)).thenReturn(allEnabledRequirements);
+        approvalService.changeState(Arrays.asList(requirement), fromState, "userId", true, getter, new ApprovalService.CopyOnStateChangeAction(requirementRepository, requirementApprovalStateTransitionRepository));
+        Assert.assertEquals(false, requirement.isCurrent());
+    }
+
+
+    @Test
+    public void testForwardFlowWithToStateEntity() {
+        String fromState = RequirementApprovalState.PRE_PROPOSED.toString();
+        String toState =  RequirementApprovalState.PROPOSED.toString();
+        boolean forward = true;
+        Requirement requirement = createRequirement(fromState, true);
+        Function<Requirement, String> getter = Requirement::getState;
+        RequirementApprovalTransition requirementApprovalTransition = TestHelper.getRequirementApprovalTransition(Constants.DEFAULT_TRANSITION_GROUP, fromState, toState, forward);
+        Mockito.when(requirementApprovalStateTransitionRepository.getApprovalTransition(Mockito.anyString(), Mockito.eq(true))).thenReturn(Arrays.asList(requirementApprovalTransition));
+        List<Requirement> allEnabledRequirements = Arrays.asList(createRequirement(toState, false));
+        Mockito.doNothing().when(requirementRepository).updateProjections(Mockito.anyList(), Mockito.anyMap());
+        Mockito.when(requirementRepository.find(Arrays.asList("fsn1"), true)).thenReturn(allEnabledRequirements);
+        approvalService.changeState(Arrays.asList(requirement), fromState, "userId", true, getter, new ApprovalService.CopyOnStateChangeAction(requirementRepository, requirementApprovalStateTransitionRepository));
+        Assert.assertEquals(false, requirement.isCurrent());
+    }
+
+
+    private Requirement createRequirement(String state, boolean current) {
         Requirement requirement = new Requirement();
         requirement.setFsn("fsn1");
         requirement.setState(state);
         requirement.setEnabled(true);
-        requirement.setCurrent(true);
+        requirement.setCurrent(current);
         requirement.setWarehouse("dummy_warehouse");
         requirement.setCreatedAt(new Date());
         requirement.setUpdatedAt(new Date());
-
-        Long projectionId = insertProjection("fsn1", state).longValue();
-        requirement.setProjectionId(projectionId);
-        requirementRepository.persist(requirement);
+        Group group = TestHelper.getGroup("test_group");
+        group.setId(256l);
+        RequirementSnapshot requirementSnapshot = new RequirementSnapshot();
+        requirementSnapshot.setGroup(group);
+        requirement.setRequirementSnapshot(requirementSnapshot);
         return requirement;
-    }
-    private Requirement createCdoRequirement(String state) {
-        Requirement requirement = new Requirement();
-        requirement.setFsn("fsn1");
-        requirement.setState(state);
-        requirement.setEnabled(true);
-        requirement.setCurrent(false);
-        requirement.setWarehouse("dummy_warehouse");
-        requirement.setCreatedAt(new Date());
-        requirement.setUpdatedAt(new Date());
-
-        Long projectionId = insertProjection("fsn1", state).longValue();
-        requirement.setProjectionId(projectionId);
-        requirementRepository.persist(requirement);
-        return requirement;
-    }
-    //TODO: legacy code
-    private BigInteger insertProjection(String fsn, String state) {
-        EntityManager entityManager = entityManagerProvider.get();
-        try {
-            return (BigInteger) entityManager
-                    .createNativeQuery("SELECT id FROM projections WHERE fsn=:fsn")
-                    .setParameter("fsn", fsn)
-                    .getSingleResult();
-        } catch (NoResultException ex) {
-            entityManager
-                    .createNativeQuery("INSERT INTO projections(fsn, current_state, version) VALUES( :fsn, :state, 0)")
-                    .setParameter("fsn", fsn)
-                    .setParameter("state", state)
-                    .executeUpdate();
-            return (BigInteger) entityManager
-                    .createNativeQuery("SELECT id FROM projections WHERE fsn=:fsn")
-                    .setParameter("fsn", fsn)
-                    .getSingleResult();
-        }
     }
 
     //TODO: legacy code
+
     @Before
-    public void init() {
-        String sql = "CREATE TABLE IF NOT EXISTS projections"
-                + "  (ID BIGINT GENERATED BY DEFAULT AS IDENTITY (START WITH 1, INCREMENT BY 1) NOT NULL,"
-                + "  FSN VARCHAR(32),"
-                + "  current_state varchar(32) NOT NULL,"
-                + "  PRIMARY KEY (ID))";
-        EntityManager entityManager = entityManagerProvider.get();
-        entityManager.createNativeQuery(sql).executeUpdate();
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
     }
+
+
+
 }


### PR DESCRIPTION
* Release (#33)

* Release (#92)

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* Admin port change in gradle properties

* NM cloud scripts

* persistantFilePath change in config.yml

* config name change from production to nm-cloud

* adding plugin jacoco

* Change in gradle build for jacoco plugin

* SQL statemets for new schema change

* bug fix for max cov applicator (#97)

* fixing build issues

* adding sample test

* templates for Download

* Unit test (#24)

* unit test for requiremnet repository

* unit test for repository

* Repo (#25)

* removed paginated query to db

* interface to repo

* interface extending jpagenericrepository

* typed query

* override annotation

* rebasing with upstream

* Unit tests (#26)

* server repository

* unit test for download command

* removed unnecssary binding from test module

* interface repo name changed

* Proc client (#21)

* Get last app and supplier

* table name change

* changes in fetch app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* common code to fetch last app and supplier

* RP-173 adding base repos

* requested changes from review of pull#28

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* working code

* backward compatibility changes

* backward compatibility changes

* bug fixes

* select supplier for requirement

* disabling existing requirements before creating new

* bugfix for convertDaysToQuantity

* adding test cases

* bug fix

* bugfix for negative req when inv < max cov (#98)

setting proper values for projection state and enabled

* Filterdownload (#96)

* requirement by filter

* no reuirement selected

* filetr changes

* corrected query

* query corrected

* tset fix

* page numbber as 1

* filter download

* copy error

* fsn list

* page loop

* test fix

* test fix 1

* group as list in filter

* changes of code review

* code review changes

* group as list

* fetch in criteria query

* Filterdownload (#67)

* requirement by filter

* no reuirement selected

* filetr changes

* corrected query

* query corrected

* tset fix

* page numbber as 1

* filter download

* copy error

* fsn list

* page loop

* test fix

* test fix 1

* group as list in filter

* changes of code review

* code review changes

* group as list

* fetch in criteria query

* added logs

* Release (#77)

* Release (#70)

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* Admin port change in gradle properties

* NM cloud scripts

* persistantFilePath change in config.yml

* config name change from production to nm-cloud

* adding plugin jacoco

* Approvalfix (#74)

* corrected query

* query corrected

* bizfin review fix

* download requirement request

* bugfix for convertDaysToQuantity	 (#82)

* fixing build issues

* adding sample test

* templates for Download

* Unit test (#24)

* unit test for requiremnet repository

* unit test for repository

* Repo (#25)

* removed paginated query to db

* interface to repo

* interface extending jpagenericrepository

* typed query

* override annotation

* rebasing with upstream

* Unit tests (#26)

* server repository

* unit test for download command

* removed unnecssary binding from test module

* interface repo name changed

* Proc client (#21)

* Get last app and supplier

* table name change

* changes in fetch app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* common code to fetch last app and supplier

* RP-173 adding base repos

* requested changes from review of pull#28

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* working code

* backward compatibility changes

* backward compatibility changes

* bug fixes

* select supplier for requirement

* Release (#70)

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* Admin port change in gradle properties

* NM cloud scripts

* persistantFilePath change in config.yml

* config name change from production to nm-cloud

* adding plugin jacoco

* disabling existing requirements before creating new

* Approvalfix (#74)

* corrected query

* query corrected

* bizfin review fix

* bugfix for convertDaysToQuantity

* Release (#80)

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* Admin port change in gradle properties

* NM cloud scripts

* persistantFilePath change in config.yml

* config name change from production to nm-cloud

* adding plugin jacoco

* Change in gradle build for jacoco plugin

* lock fields in template

* Dataaggregation (#106)

* Release (#31)

* Release (#92)

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* Admin port change in gradle properties

* NM cloud scripts

* persistantFilePath change in config.yml

* config name change from production to nm-cloud

* adding plugin jacoco

* Change in gradle build for jacoco plugin

* SQL statemets for new schema change

* bug fix for max cov applicator (#97)

* fixing build issues

* adding sample test

* templates for Download

* Unit test (#24)

* unit test for requiremnet repository

* unit test for repository

* Repo (#25)

* removed paginated query to db

* interface to repo

* interface extending jpagenericrepository

* typed query

* override annotation

* rebasing with upstream

* Unit tests (#26)

* server repository

* unit test for download command

* removed unnecssary binding from test module

* interface repo name changed

* Proc client (#21)

* Get last app and supplier

* table name change

* changes in fetch app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* common code to fetch last app and supplier

* RP-173 adding base repos

* requested changes from review of pull#28

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* working code

* backward compatibility changes

* backward compatibility changes

* bug fixes

* select supplier for requirement

* disabling existing requirements before creating new

* bugfix for convertDaysToQuantity

* adding test cases

* bug fix

* bugfix for negative req when inv < max cov (#98)

setting proper values for projection state and enabled

* Filterdownload (#96)

* requirement by filter

* no reuirement selected

* filetr changes

* corrected query

* query corrected

* tset fix

* page numbber as 1

* filter download

* copy error

* fsn list

* page loop

* test fix

* test fix 1

* group as list in filter

* changes of code review

* code review changes

* group as list

* fetch in criteria query

* Filterdownload (#67)

* requirement by filter

* no reuirement selected

* filetr changes

* corrected query

* query corrected

* tset fix

* page numbber as 1

* filter download

* copy error

* fsn list

* page loop

* test fix

* test fix 1

* group as list in filter

* changes of code review

* code review changes

* group as list

* fetch in criteria query

* added logs

* Release (#77)

* Release (#70)

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* Admin port change in gradle properties

* NM cloud scripts

* persistantFilePath change in config.yml

* config name change from production to nm-cloud

* adding plugin jacoco

* Approvalfix (#74)

* corrected query

* query corrected

* bizfin review fix

* download requirement request

* bugfix for convertDaysToQuantity	 (#82)

* fixing build issues

* adding sample test

* templates for Download

* Unit test (#24)

* unit test for requiremnet repository

* unit test for repository

* Repo (#25)

* removed paginated query to db

* interface to repo

* interface extending jpagenericrepository

* typed query

* override annotation

* rebasing with upstream

* Unit tests (#26)

* server repository

* unit test for download command

* removed unnecssary binding from test module

* interface repo name changed

* Proc client (#21)

* Get last app and supplier

* table name change

* changes in fetch app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* common code to fetch last app and supplier

* RP-173 adding base repos

* requested changes from review of pull#28

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* working code

* backward compatibility changes

* backward compatibility changes

* bug fixes

* select supplier for requirement

* Release (#70)

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* Admin port change in gradle properties

* NM cloud scripts

* persistantFilePath change in config.yml

* config name change from production to nm-cloud

* adding plugin jacoco

* disabling existing requirements before creating new

* Approvalfix (#74)

* corrected query

* query corrected

* bizfin review fix

* bugfix for convertDaysToQuantity

* Release (#80)

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* Admin port change in gradle properties

* NM cloud scripts

* persistantFilePath change in config.yml

* config name change from production to nm-cloud

* adding plugin jacoco

* Change in gradle build for jacoco plugin

* lock fields in template

* data aggregation command for search and download

* class name changed

* sql checkin for alter table in product info (#19)

* adding wrapper gradle changes and heapmemory changes

* adding the alter table command for PRODUCT_INFO table

* Zulu product info cron checkin (#111)

* adding wrapper gradle changes and heapmemory changes

* getting product details from zulu

* adding the files

* adding review changes

* taking batch variable outside of the loop

* adding zulu changes

* correcting sql queries

* SLA Changes (#109)

* sla changes

* using ProductInfo instead of ProcPurchaseOrder for getting vertical

* Milestone0 (#112)

* adding wrapper gradle changes and heapmemory changes

* upload_temp_commit

* upload_temp_commit for override save

* upload_temp_commit for adding changes

* upload_temp_commit for removing overhead

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* bizfin empty quantity and comment fix

* correcting enum constructor and no update fix

* persistantFilePath change in config.yml (#57)

* persistantFilePath change in config.yml

* config name change from production to nm-cloud

* adding unit test cases and CR changes

* removing unnecessary changes

* adding ssl config to nm-cloud-test

* adding ssl config

* Filterdownload (#67)

* requirement by filter

* no reuirement selected

* filetr changes

* corrected query

* query corrected

* tset fix

* page numbber as 1

* filter download

* copy error

* fsn list

* page loop

* test fix

* test fix 1

* group as list in filter

* changes of code review

* code review changes

* group as list

* fetch in criteria query

* logging configs

* logging configs

* logging configs

* Filterdownload (#69)

* requirement by filter

* no reuirement selected

* filetr changes

* corrected query

* query corrected

* tset fix

* page numbber as 1

* filter download

* copy error

* fsn list

* page loop

* test fix

* test fix 1

* group as list in filter

* changes of code review

* code review changes

* group as list

* fetch in criteria query

* added logs

* adding CR changes

* removing unnecessary changes

* Upload changes(not final code) (#72)

* adding wrapper gradle changes and heapmemory changes

* upload_temp_commit

* upload_temp_commit for override save

* upload_temp_commit for adding changes

* upload_temp_commit for removing overhead

* bizfin empty quantity and comment fix

* correcting enum constructor and no update fix

* adding unit test cases and CR changes

* removing unnecessary changes

* req calculation changes (#66)

* fixing build issues

* adding sample test

* templates for Download

* Unit test (#24)

* unit test for requiremnet repository

* unit test for repository

* Repo (#25)

* removed paginated query to db

* interface to repo

* interface extending jpagenericrepository

* typed query

* override annotation

* rebasing with upstream

* Unit tests (#26)

* server repository

* unit test for download command

* removed unnecssary binding from test module

* interface repo name changed

* Proc client (#21)

* Get last app and supplier

* table name change

* changes in fetch app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* common code to fetch last app and supplier

* RP-173 adding base repos

* requested changes from review of pull#28

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* working code

* backward compatibility changes

* backward compatibility changes

* bug fixes

* select supplier for requirement

* Release (#70)

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* Admin port change in gradle properties

* NM cloud scripts

* persistantFilePath change in config.yml

* config name change from production to nm-cloud

* adding plugin jacoco

* adding CR changes

* removing unnecessary changes

* Release (#77)

* Release (#70)

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* Admin port change in gradle properties

* NM cloud scripts

* persistantFilePath change in config.yml

* config name change from production to nm-cloud

* adding plugin jacoco

* Approvalfix (#74)

* corrected query

* query corrected

* bizfin review fix

* renaming file name and correcting config

* bugfix for convertDaysToQuantity	 (#82)

* fixing build issues

* adding sample test

* templates for Download

* Unit test (#24)

* unit test for requiremnet repository

* unit test for repository

* Repo (#25)

* removed paginated query to db

* interface to repo

* interface extending jpagenericrepository

* typed query

* override annotation

* rebasing with upstream

* Unit tests (#26)

* server repository

* unit test for download command

* removed unnecssary binding from test module

* interface repo name changed

* Proc client (#21)

* Get last app and supplier

* table name change

* changes in fetch app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* common code to fetch last app and supplier

* RP-173 adding base repos

* requested changes from review of pull#28

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* working code

* backward compatibility changes

* backward compatibility changes

* bug fixes

* select supplier for requirement

* Release (#70)

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* Admin port change in gradle properties

* NM cloud scripts

* persistantFilePath change in config.yml

* config name change from production to nm-cloud

* adding plugin jacoco

* disabling existing requirements before creating new

* Approvalfix (#74)

* corrected query

* query corrected

* bizfin review fix

* bugfix for convertDaysToQuantity

* Release (#80)

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* Admin port change in gradle properties

* NM cloud scripts

* persistantFilePath change in config.yml

* config name change from production to nm-cloud

* adding plugin jacoco

* Change in gradle build for jacoco plugin

* Filterdownload (#84)

* requirement by filter

* no reuirement selected

* filetr changes

* corrected query

* query corrected

* tset fix

* page numbber as 1

* filter download

* copy error

* fsn list

* page loop

* test fix

* test fix 1

* group as list in filter

* changes of code review

* code review changes

* group as list

* fetch in criteria query

* Filterdownload (#67)

* requirement by filter

* no reuirement selected

* filetr changes

* corrected query

* query corrected

* tset fix

* page numbber as 1

* filter download

* copy error

* fsn list

* page loop

* test fix

* test fix 1

* group as list in filter

* changes of code review

* code review changes

* group as list

* fetch in criteria query

* added logs

* download requirement request

* merge fixes

* added import fetch type

* adding few changes for debug

* removing unnecessary changes

* adding build failure fixes

* commenting out jacoco plugin code to build

* removing script to run test file for jacoco

* remove pagination in approval service

* removing unnecessary persist and commenting test cases

* optimisation and fixes

* removing comments and fixes

* correcting config file

* db config in nm cloud

* fixed bizfin quantity

* Revert "fixed bizfin quantity"

This reverts commit 407aa00831afae3b8cb32ac1bec336ff90b5c6bf.

* fixed equality of int and integer

* correcting empty check

* set current as false for existing requirements

* template changes (#103)

* adding review changes and supplier fix

* removing unnecessary changes

* removing size check

* Template changes (#108)

* template changes

* removed template validations

* unprotect sheet

* logs for approval service

* adding zero quantity fix and try catch to handle some exceptions (#110)

* log rotation changes (#107)

* log rotation changes

* log rotate chnages

* 500 mb for request log

* chaging the timezone to Asia/Calcutta

* reverting the config.yaml of development env

* removing ssl config import from managerConfig which was added for testing purpose

* removing spaces and adding maxfilesize in test config for request logs

* changes in display messages in ui (#115)

* changes for display strings in UI

* Release (#34)

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* persistantFilePath change in config.yml (#57)

* persistantFilePath change in config.yml

* config name change from production to nm-cloud

* adding ssl config to nm-cloud-test

* adding ssl config

* logging configs

* logging configs

* logging configs

* Release (#92)

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* Admin port change in gradle properties

* NM cloud scripts

* persistantFilePath change in config.yml

* config name change from production to nm-cloud

* adding plugin jacoco

* Change in gradle build for jacoco plugin

* SQL statemets for new schema change

* bug fix for max cov applicator (#97)

* fixing build issues

* adding sample test

* templates for Download

* Unit test (#24)

* unit test for requiremnet repository

* unit test for repository

* Repo (#25)

* removed paginated query to db

* interface to repo

* interface extending jpagenericrepository

* typed query

* override annotation

* rebasing with upstream

* Unit tests (#26)

* server repository

* unit test for download command

* removed unnecssary binding from test module

* interface repo name changed

* Proc client (#21)

* Get last app and supplier

* table name change

* changes in fetch app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* common code to fetch last app and supplier

* RP-173 adding base repos

* requested changes from review of pull#28

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* working code

* backward compatibility changes

* backward compatibility changes

* bug fixes

* select supplier for requirement

* disabling existing requirements before creating new

* bugfix for convertDaysToQuantity

* adding test cases

* bug fix

* bugfix for negative req when inv < max cov (#98)

setting proper values for projection state and enabled

* db config in nm cloud

* Filterdownload (#96)

* requirement by filter

* no reuirement selected

* filetr changes

* corrected query

* query corrected

* tset fix

* page numbber as 1

* filter download

* copy error

* fsn list

* page loop

* test fix

* test fix 1

* group as list in filter

* changes of code review

* code review changes

* group as list

* fetch in criteria query

* Filterdownload (#67)

* requirement by filter

* no reuirement selected

* filetr changes

* corrected query

* query corrected

* tset fix

* page numbber as 1

* filter download

* copy error

* fsn list

* page loop

* test fix

* test fix 1

* group as list in filter

* changes of code review

* code review changes

* group as list

* fetch in criteria query

* added logs

* Release (#77)

* Release (#70)

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* Admin port change in gradle properties

* NM cloud scripts

* persistantFilePath change in config.yml

* config name change from production to nm-cloud

* adding plugin jacoco

* Approvalfix (#74)

* corrected query

* query corrected

* bizfin review fix

* download requirement request

* bugfix for convertDaysToQuantity	 (#82)

* fixing build issues

* adding sample test

* templates for Download

* Unit test (#24)

* unit test for requiremnet repository

* unit test for repository

* Repo (#25)

* removed paginated query to db

* interface to repo

* interface extending jpagenericrepository

* typed query

* override annotation

* rebasing with upstream

* Unit tests (#26)

* server repository

* unit test for download command

* removed unnecssary binding from test module

* interface repo name changed

* Proc client (#21)

* Get last app and supplier

* table name change

* changes in fetch app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* common code to fetch last app and supplier

* RP-173 adding base repos

* requested changes from review of pull#28

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* working code

* backward compatibility changes

* backward compatibility changes

* bug fixes

* select supplier for requirement

* Release (#70)

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* Admin port change in gradle properties

* NM cloud scripts

* persistantFilePath change in config.yml

* config name change from production to nm-cloud

* adding plugin jacoco

* disabling existing requirements before creating new

* Approvalfix (#74)

* corrected query

* query corrected

* bizfin review fix

* bugfix for convertDaysToQuantity

* Release (#80)

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* Admin port change in gradle properties

* NM cloud scripts

* persistantFilePath change in config.yml

* config name change from production to nm-cloud

* adding plugin jacoco

* Change in gradle build for jacoco plugin

* lock fields in template

* Dataaggregation (#106)

* Release (#31)

* Release (#92)

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* Admin port change in gradle properties

* NM cloud scripts

* persistantFilePath change in config.yml

* config name change from production to nm-cloud

* adding plugin jacoco

* Change in gradle build for jacoco plugin

* SQL statemets for new schema change

* bug fix for max cov applicator (#97)

* fixing build issues

* adding sample test

* templates for Download

* Unit test (#24)

* unit test for requiremnet repository

* unit test for repository

* Repo (#25)

* removed paginated query to db

* interface to repo

* interface extending jpagenericrepository

* typed query

* override annotation

* rebasing with upstream

* Unit tests (#26)

* server repository

* unit test for download command

* removed unnecssary binding from test module

* interface repo name changed

* Proc client (#21)

* Get last app and supplier

* table name change

* changes in fetch app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* common code to fetch last app and supplier

* RP-173 adding base repos

* requested changes from review of pull#28

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* working code

* backward compatibility changes

* backward compatibility changes

* bug fixes

* select supplier for requirement

* disabling existing requirements before creating new

* bugfix for convertDaysToQuantity

* adding test cases

* bug fix

* bugfix for negative req when inv < max cov (#98)

setting proper values for projection state and enabled

* Filterdownload (#96)

* requirement by filter

* no reuirement selected

* filetr changes

* corrected query

* query corrected

* tset fix

* page numbber as 1

* filter download

* copy error

* fsn list

* page loop

* test fix

* test fix 1

* group as list in filter

* changes of code review

* code review changes

* group as list

* fetch in criteria query

* Filterdownload (#67)

* requirement by filter

* no reuirement selected

* filetr changes

* corrected query

* query corrected

* tset fix

* page numbber as 1

* filter download

* copy error

* fsn list

* page loop

* test fix

* test fix 1

* group as list in filter

* changes of code review

* code review changes

* group as list

* fetch in criteria query

* added logs

* Release (#77)

* Release (#70)

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* Admin port change in gradle properties

* NM cloud scripts

* persistantFilePath change in config.yml

* config name change from production to nm-cloud

* adding plugin jacoco

* Approvalfix (#74)

* corrected query

* query corrected

* bizfin review fix

* download requirement request

* bugfix for convertDaysToQuantity	 (#82)

* fixing build issues

* adding sample test

* templates for Download

* Unit test (#24)

* unit test for requiremnet repository

* unit test for repository

* Repo (#25)

* removed paginated query to db

* interface to repo

* interface extending jpagenericrepository

* typed query

* override annotation

* rebasing with upstream

* Unit tests (#26)

* server repository

* unit test for download command

* removed unnecssary binding from test module

* interface repo name changed

* Proc client (#21)

* Get last app and supplier

* table name change

* changes in fetch app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* common code to fetch last app and supplier

* RP-173 adding base repos

* requested changes from review of pull#28

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* working code

* backward compatibility changes

* backward compatibility changes

* bug fixes

* select supplier for requirement

* Release (#70)

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* Admin port change in gradle properties

* NM cloud scripts

* persistantFilePath change in config.yml

* config name change from production to nm-cloud

* adding plugin jacoco

* disabling existing requirements before creating new

* Approvalfix (#74)

* corrected query

* query corrected

* bizfin review fix

* bugfix for convertDaysToQuantity

* Release (#80)

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* Admin port change in gradle properties

* NM cloud scripts

* persistantFilePath change in config.yml

* config name change from production to nm-cloud

* adding plugin jacoco

* Change in gradle build for jacoco plugin

* lock fields in template

* data aggregation command for search and download

* class name changed

* sql checkin for alter table in product info (#19)

* adding wrapper gradle changes and heapmemory changes

* adding the alter table command for PRODUCT_INFO table

* Zulu product info cron checkin (#111)

* adding wrapper gradle changes and heapmemory changes

* getting product details from zulu

* adding the files

* adding review changes

* taking batch variable outside of the loop

* adding zulu changes

* correcting sql queries

* log rotation changes (#107)

* log rotation changes

* log rotate chnages

* 500 mb for request log

* chaging the timezone to Asia/Calcutta

* reverting the config.yaml of development env

* removing ssl config import from managerConfig which was added for testing purpose

* removing spaces and adding maxfilesize in test config for request logs

* SLA Changes (#109)

* sla changes

* using ProductInfo instead of ProcPurchaseOrder for getting vertical

* Milestone0 (#112)

* adding wrapper gradle changes and heapmemory changes

* upload_temp_commit

* upload_temp_commit for override save

* upload_temp_commit for adding changes

* upload_temp_commit for removing overhead

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* bizfin empty quantity and comment fix

* correcting enum constructor and no update fix

* persistantFilePath change in config.yml (#57)

* persistantFilePath change in config.yml

* config name change from production to nm-cloud

* adding unit test cases and CR changes

* removing unnecessary changes

* adding ssl config to nm-cloud-test

* adding ssl config

* Filterdownload (#67)

* requirement by filter

* no reuirement selected

* filetr changes

* corrected query

* query corrected

* tset fix

* page numbber as 1

* filter download

* copy error

* fsn list

* page loop

* test fix

* test fix 1

* group as list in filter

* changes of code review

* code review changes

* group as list

* fetch in criteria query

* logging configs

* logging configs

* logging configs

* Filterdownload (#69)

* requirement by filter

* no reuirement selected

* filetr changes

* corrected query

* query corrected

* tset fix

* page numbber as 1

* filter download

* copy error

* fsn list

* page loop

* test fix

* test fix 1

* group as list in filter

* changes of code review

* code review changes

* group as list

* fetch in criteria query

* added logs

* adding CR changes

* removing unnecessary changes

* Upload changes(not final code) (#72)

* adding wrapper gradle changes and heapmemory changes

* upload_temp_commit

* upload_temp_commit for override save

* upload_temp_commit for adding changes

* upload_temp_commit for removing overhead

* bizfin empty quantity and comment fix

* correcting enum constructor and no update fix

* adding unit test cases and CR changes

* removing unnecessary changes

* req calculation changes (#66)

* fixing build issues

* adding sample test

* templates for Download

* Unit test (#24)

* unit test for requiremnet repository

* unit test for repository

* Repo (#25)

* removed paginated query to db

* interface to repo

* interface extending jpagenericrepository

* typed query

* override annotation

* rebasing with upstream

* Unit tests (#26)

* server repository

* unit test for download command

* removed unnecssary binding from test module

* interface repo name changed

* Proc client (#21)

* Get last app and supplier

* table name change

* changes in fetch app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* common code to fetch last app and supplier

* RP-173 adding base repos

* requested changes from review of pull#28

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* working code

* backward compatibility changes

* backward compatibility changes

* bug fixes

* select supplier for requirement

* Release (#70)

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* Admin port change in gradle properties

* NM cloud scripts

* persistantFilePath change in config.yml

* config name change from production to nm-cloud

* adding plugin jacoco

* adding CR changes

* removing unnecessary changes

* Release (#77)

* Release (#70)

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* Admin port change in gradle properties

* NM cloud scripts

* persistantFilePath change in config.yml

* config name change from production to nm-cloud

* adding plugin jacoco

* Approvalfix (#74)

* corrected query

* query corrected

* bizfin review fix

* renaming file name and correcting config

* bugfix for convertDaysToQuantity	 (#82)

* fixing build issues

* adding sample test

* templates for Download

* Unit test (#24)

* unit test for requiremnet repository

* unit test for repository

* Repo (#25)

* removed paginated query to db

* interface to repo

* interface extending jpagenericrepository

* typed query

* override annotation

* rebasing with upstream

* Unit tests (#26)

* server repository

* unit test for download command

* removed unnecssary binding from test module

* interface repo name changed

* Proc client (#21)

* Get last app and supplier

* table name change

* changes in fetch app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* common code to fetch last app and supplier

* RP-173 adding base repos

* requested changes from review of pull#28

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* working code

* backward compatibility changes

* backward compatibility changes

* bug fixes

* select supplier for requirement

* Release (#70)

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* Admin port change in gradle properties

* NM cloud scripts

* persistantFilePath change in config.yml

* config name change from production to nm-cloud

* adding plugin jacoco

* disabling existing requirements before creating new

* Approvalfix (#74)

* corrected query

* query corrected

* bizfin review fix

* bugfix for convertDaysToQuantity

* Release (#80)

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* Admin port change in gradle properties

* NM cloud scripts

* persistantFilePath change in config.yml

* config name change from production to nm-cloud

* adding plugin jacoco

* Change in gradle build for jacoco plugin

* Filterdownload (#84)

* requirement by filter

* no reuirement selected

* filetr changes

* corrected query

* query corrected

* tset fix

* page numbber as 1

* filter download

* copy error

* fsn list

* page loop

* test fix

* test fix 1

* group as list in filter

* changes of code review

* code review changes

* group as list

* fetch in criteria query

* Filterdownload (#67)

* requirement by filter

* no reuirement selected

* filetr changes

* corrected query

* query corrected

* tset fix

* page numbber as 1

* filter download

* copy error

* fsn list

* page loop

* test fix

* test fix 1

* group as list in filter

* changes of code review

* code review changes

* group as list

* fetch in criteria query

* added logs

* download requirement request

* merge fixes

* added import fetch type

* adding few changes for debug

* removing unnecessary changes

* adding build failure fixes

* commenting out jacoco plugin code to build

* removing script to run test file for jacoco

* remove pagination in approval service

* removing unnecessary persist and commenting test cases

* optimisation and fixes

* removing comments and fixes

* correcting config file

* db config in nm cloud

* fixed bizfin quantity

* Revert "fixed bizfin quantity"

This reverts commit 407aa00831afae3b8cb32ac1bec336ff90b5c6bf.

* fixed equality of int and integer

* correcting empty check

* set current as false for existing requirements

* template changes (#103)

* adding review changes and supplier fix

* removing unnecessary changes

* removing size check

* Template changes (#108)

* template changes

* removed template validations

* unprotect sheet

* logs for approval service

* adding zero quantity fix and try catch to handle some exceptions (#110)

* log rotation changes (#107)

* log rotation changes

* log rotate chnages

* 500 mb for request log

* chaging the timezone to Asia/Calcutta

* reverting the config.yaml of development env

* removing ssl config import from managerConfig which was added for testing purpose

* removing spaces and adding maxfilesize in test config for request logs

* changes for Logrotate for test config (#113)

* log rotation changes

* log rotate chnages

* 500 mb for request log

* chaging the timezone to Asia/Calcutta

* reverting the config.yaml of development env

* removing ssl config import from managerConfig which was added for testing purpose

* removing spaces and adding maxfilesize in test config for request logs

* changing test log config to 500MB

* changes in display messages in ui (#115)

* changes for display strings in UI

* Filtercommand (#116)

* filter fsns start with all fsns

* Release (#35)

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* persistantFilePath change in config.yml (#57)

* persistantFilePath change in config.yml

* config name change from production to nm-cloud

* adding ssl config to nm-cloud-test

* adding ssl config

* logging configs

* logging configs

* logging configs

* Release (#92)

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* Admin port change in gradle properties

* NM cloud scripts

* persistantFilePath change in config.yml

* config name change from production to nm-cloud

* adding plugin jacoco

* Change in gradle build for jacoco plugin

* SQL statemets for new schema change

* bug fix for max cov applicator (#97)

* fixing build issues

* adding sample test

* templates for Download

* Unit test (#24)

* unit test for requiremnet repository

* unit test for repository

* Repo (#25)

* removed paginated query to db

* interface to repo

* interface extending jpagenericrepository

* typed query

* override annotation

* rebasing with upstream

* Unit tests (#26)

* server repository

* unit test for download command

* removed unnecssary binding from test module

* interface repo name changed

* Proc client (#21)

* Get last app and supplier

* table name change

* changes in fetch app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* common code to fetch last app and supplier

* RP-173 adding base repos

* requested changes from review of pull#28

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* working code

* backward compatibility changes

* backward compatibility changes

* bug fixes

* select supplier for requirement

* disabling existing requirements before creating new

* bugfix for convertDaysToQuantity

* adding test cases

* bug fix

* bugfix for negative req when inv < max cov (#98)

setting proper values for projection state and enabled

* db config in nm cloud

* Filterdownload (#96)

* requirement by filter

* no reuirement selected

* filetr changes

* corrected query

* query corrected

* tset fix

* page numbber as 1

* filter download

* copy error

* fsn list

* page loop

* test fix

* test fix 1

* group as list in filter

* changes of code review

* code review changes

* group as list

* fetch in criteria query

* Filterdownload (#67)

* requirement by filter

* no reuirement selected

* filetr changes

* corrected query

* query corrected

* tset fix

* page numbber as 1

* filter download

* copy error

* fsn list

* page loop

* test fix

* test fix 1

* group as list in filter

* changes of code review

* code review changes

* group as list

* fetch in criteria query

* added logs

* Release (#77)

* Release (#70)

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* Admin port change in gradle properties

* NM cloud scripts

* persistantFilePath change in config.yml

* config name change from production to nm-cloud

* adding plugin jacoco

* Approvalfix (#74)

* corrected query

* query corrected

* bizfin review fix

* download requirement request

* bugfix for convertDaysToQuantity	 (#82)

* fixing build issues

* adding sample test

* templates for Download

* Unit test (#24)

* unit test for requiremnet repository

* unit test for repository

* Repo (#25)

* removed paginated query to db

* interface to repo

* interface extending jpagenericrepository

* typed query

* override annotation

* rebasing with upstream

* Unit tests (#26)

* server repository

* unit test for download command

* removed unnecssary binding from test module

* interface repo name changed

* Proc client (#21)

* Get last app and supplier

* table name change

* changes in fetch app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* common code to fetch last app and supplier

* RP-173 adding base repos

* requested changes from review of pull#28

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* working code

* backward compatibility changes

* backward compatibility changes

* bug fixes

* select supplier for requirement

* Release (#70)

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* Admin port change in gradle properties

* NM cloud scripts

* persistantFilePath change in config.yml

* config name change from production to nm-cloud

* adding plugin jacoco

* disabling existing requirements before creating new

* Approvalfix (#74)

* corrected query

* query corrected

* bizfin review fix

* bugfix for convertDaysToQuantity

* Release (#80)

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* Admin port change in gradle properties

* NM cloud scripts

* persistantFilePath change in config.yml

* config name change from production to nm-cloud

* adding plugin jacoco

* Change in gradle build for jacoco plugin

* lock fields in template

* Dataaggregation (#106)

* Release (#31)

* Release (#92)

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* Admin port change in gradle properties

* NM cloud scripts

* persistantFilePath change in config.yml

* config name change from production to nm-cloud

* adding plugin jacoco

* Change in gradle build for jacoco plugin

* SQL statemets for new schema change

* bug fix for max cov applicator (#97)

* fixing build issues

* adding sample test

* templates for Download

* Unit test (#24)

* unit test for requiremnet repository

* unit test for repository

* Repo (#25)

* removed paginated query to db

* interface to repo

* interface extending jpagenericrepository

* typed query

* override annotation

* rebasing with upstream

* Unit tests (#26)

* server repository

* unit test for download command

* removed unnecssary binding from test module

* interface repo name changed

* Proc client (#21)

* Get last app and supplier

* table name change

* changes in fetch app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* common code to fetch last app and supplier

* RP-173 adding base repos

* requested changes from review of pull#28

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* working code

* backward compatibility changes

* backward compatibility changes

* bug fixes

* select supplier for requirement

* disabling existing requirements before creating new

* bugfix for convertDaysToQuantity

* adding test cases

* bug fix

* bugfix for negative req when inv < max cov (#98)

setting proper values for projection state and enabled

* Filterdownload (#96)

* requirement by filter

* no reuirement selected

* filetr changes

* corrected query

* query corrected

* tset fix

* page numbber as 1

* filter download

* copy error

* fsn list

* page loop

* test fix

* test fix 1

* group as list in filter

* changes of code review

* code review changes

* group as list

* fetch in criteria query

* Filterdownload (#67)

* requirement by filter

* no reuirement selected

* filetr changes

* corrected query

* query corrected

* tset fix

* page numbber as 1

* filter download

* copy error

* fsn list

* page loop

* test fix

* test fix 1

* group as list in filter

* changes of code review

* code review changes

* group as list

* fetch in criteria query

* added logs

* Release (#77)

* Release (#70)

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* Admin port change in gradle properties

* NM cloud scripts

* persistantFilePath change in config.yml

* config name change from production to nm-cloud

* adding plugin jacoco

* Approvalfix (#74)

* corrected query

* query corrected

* bizfin review fix

* download requirement request

* bugfix for convertDaysToQuantity	 (#82)

* fixing build issues

* adding sample test

* templates for Download

* Unit test (#24)

* unit test for requiremnet repository

* unit test for repository

* Repo (#25)

* removed paginated query to db

* interface to repo

* interface extending jpagenericrepository

* typed query

* override annotation

* rebasing with upstream

* Unit tests (#26)

* server repository

* unit test for download command

* removed unnecssary binding from test module

* interface repo name changed

* Proc client (#21)

* Get last app and supplier

* table name change

* changes in fetch app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* common code to fetch last app and supplier

* RP-173 adding base repos

* requested changes from review of pull#28

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* working code

* backward compatibility changes

* backward compatibility changes

* bug fixes

* select supplier for requirement

* Release (#70)

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* Admin port change in gradle properties

* NM cloud scripts

* persistantFilePath change in config.yml

* config name change from production to nm-cloud

* adding plugin jacoco

* disabling existing requirements before creating new

* Approvalfix (#74)

* corrected query

* query corrected

* bizfin review fix

* bugfix for convertDaysToQuantity

* Release (#80)

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* Admin port change in gradle properties

* NM cloud scripts

* persistantFilePath change in config.yml

* config name change from production to nm-cloud

* adding plugin jacoco

* Change in gradle build for jacoco plugin

* lock fields in template

* data aggregation command for search and download

* class name changed

* sql checkin for alter table in product info (#19)

* adding wrapper gradle changes and heapmemory changes

* adding the alter table command for PRODUCT_INFO table

* Zulu product info cron checkin (#111)

* adding wrapper gradle changes and heapmemory changes

* getting product details from zulu

* adding the files

* adding review changes

* taking batch variable outside of the loop

* adding zulu changes

* correcting sql queries

* log rotation changes (#107)

* log rotation changes

* log rotate chnages

* 500 mb for request log

* chaging the timezone to Asia/Calcutta

* reverting the config.yaml of development env

* removing ssl config import from managerConfig which was added for testing purpose

* removing spaces and adding maxfilesize in test config for request logs

* SLA Changes (#109)

* sla changes

* using ProductInfo instead of ProcPurchaseOrder for getting vertical

* Milestone0 (#112)

* adding wrapper gradle changes and heapmemory changes

* upload_temp_commit

* upload_temp_commit for override save

* upload_temp_commit for adding changes

* upload_temp_commit for removing overhead

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* bizfin empty quantity and comment fix

* correcting enum constructor and no update fix

* persistantFilePath change in config.yml (#57)

* persistantFilePath change in config.yml

* config name change from production to nm-cloud

* adding unit test cases and CR changes

* removing unnecessary changes

* adding ssl config to nm-cloud-test

* adding ssl config

* Filterdownload (#67)

* requirement by filter

* no reuirement selected

* filetr changes

* corrected query

* query corrected

* tset fix

* page numbber as 1

* filter download

* copy error

* fsn list

* page loop

* test fix

* test fix 1

* group as list in filter

* changes of code review

* code review changes

* group as list

* fetch in criteria query

* logging configs

* logging configs

* logging configs

* Filterdownload (#69)

* requirement by filter

* no reuirement selected

* filetr changes

* corrected query

* query corrected

* tset fix

* page numbber as 1

* filter download

* copy error

* fsn list

* page loop

* test fix

* test fix 1

* group as list in filter

* changes of code review

* code review changes

* group as list

* fetch in criteria query

* added logs

* adding CR changes

* removing unnecessary changes

* Upload changes(not final code) (#72)

* adding wrapper gradle changes and heapmemory changes

* upload_temp_commit

* upload_temp_commit for override save

* upload_temp_commit for adding changes

* upload_temp_commit for removing overhead

* bizfin empty quantity and comment fix

* correcting enum constructor and no update fix

* adding unit test cases and CR changes

* removing unnecessary changes

* req calculation changes (#66)

* fixing build issues

* adding sample test

* templates for Download

* Unit test (#24)

* unit test for requiremnet repository

* unit test for repository

* Repo (#25)

* removed paginated query to db

* interface to repo

* interface extending jpagenericrepository

* typed query

* override annotation

* rebasing with upstream

* Unit tests (#26)

* server repository

* unit test for download command

* removed unnecssary binding from test module

* interface repo name changed

* Proc client (#21)

* Get last app and supplier

* table name change

* changes in fetch app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* common code to fetch last app and supplier

* RP-173 adding base repos

* requested changes from review of pull#28

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* working code

* backward compatibility changes

* backward compatibility changes

* bug fixes

* select supplier for requirement

* Release (#70)

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* Admin port change in gradle properties

* NM cloud scripts

* persistantFilePath change in config.yml

* config name change from production to nm-cloud

* adding plugin jacoco

* adding CR changes

* removing unnecessary changes

* Release (#77)

* Release (#70)

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* Admin port change in gradle properties

* NM cloud scripts

* persistantFilePath change in config.yml

* config name change from production to nm-cloud

* adding plugin jacoco

* Approvalfix (#74)

* corrected query

* query corrected

* bizfin review fix

* renaming file name and correcting config

* bugfix for convertDaysToQuantity	 (#82)

* fixing build issues

* adding sample test

* templates for Download

* Unit test (#24)

* unit test for requiremnet repository

* unit test for repository

* Repo (#25)

* removed paginated query to db

* interface to repo

* interface extending jpagenericrepository

* typed query

* override annotation

* rebasing with upstream

* Unit tests (#26)

* server repository

* unit test for download command

* removed unnecssary binding from test module

* interface repo name changed

* Proc client (#21)

* Get last app and supplier

* table name change

* changes in fetch app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* common code to fetch last app and supplier

* RP-173 adding base repos

* requested changes from review of pull#28

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* working code

* backward compatibility changes

* backward compatibility changes

* bug fixes

* select supplier for requirement

* Release (#70)

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* Admin port change in gradle properties

* NM cloud scripts

* persistantFilePath change in config.yml

* config name change from production to nm-cloud

* adding plugin jacoco

* disabling existing requirements before creating new

* Approvalfix (#74)

* corrected query

* query corrected

* bizfin review fix

* bugfix for convertDaysToQuantity

* Release (#80)

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* Admin port change in gradle properties

* NM cloud scripts

* persistantFilePath change in config.yml

* config name change from production to nm-cloud

* adding plugin jacoco

* Change in gradle build for jacoco plugin

* Filterdownload (#84)

* requirement by filter

* no reuirement selected

* filetr changes

* corrected query

* query corrected

* tset fix

* page numbber as 1

* filter download

* copy error

* fsn list

* page loop

* test fix

* test fix 1

* group as list in filter

* changes of code review

* code review changes

* group as list

* fetch in criteria query

* Filterdownload (#67)

* requirement by filter

* no reuirement selected

* filetr changes

* corrected query

* query corrected

* tset fix

* page numbber as 1

* filter download

* copy error

* fsn list

* page loop

* test fix

* test fix 1

* group as list in filter

* changes of code review

* code review changes

* group as list

* fetch in criteria query

* added logs

* download requirement request

* merge fixes

* added import fetch type

* adding few changes for debug

* removing unnecessary changes

* adding build failure fixes

* commenting out jacoco plugin code to build

* removing script to run test file for jacoco

* remove pagination in approval service

* removing unnecessary persist and commenting test cases

* optimisation and fixes

* removing comments and fixes

* correcting config file

* db config in nm cloud

* fixed bizfin quantity

* Revert "fixed bizfin quantity"

This reverts commit 407aa00831afae3b8cb32ac1bec336ff90b5c6bf.

* fixed equality of int and integer

* correcting empty check

* set current as false for existing requirements

* template changes (#103)

* adding review changes and supplier fix

* removing unnecessary changes

* removing size check

* Template changes (#108)

* template changes

* removed template validations

* unprotect sheet

* logs for approval service

* adding zero quantity fix and try catch to handle some exceptions (#110)

* log rotation changes (#107)

* log rotation changes

* log rotate chnages

* 500 mb for request log

* chaging the timezone to Asia/Calcutta

* reverting the config.yaml of development env

* removing ssl config import from managerConfig which was added for testing purpose

* removing spaces and adding maxfilesize in test config for request logs

* changes for Logrotate for test config (#113)

* log rotation changes

* log rotate chnages

* 500 mb for request log

* chaging the timezone to Asia/Calcutta

* reverting the config.yaml of development env

* removing ssl config import from managerConfig which was added for testing purpose

* removing spaces and adding maxfilesize in test config for request logs

* changing test log config to 500MB

* changes in display messages in ui (#115)

* changes for display strings in UI

* Filtercommand (#116)

* filter fsns start with all fsns

* Release (#36)

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* persistantFilePath change in config.yml (#57)

* persistantFilePath change in config.yml

* config name change from production to nm-cloud

* adding ssl config to nm-cloud-test

* adding ssl config

* logging configs

* logging configs

* logging configs

* Release (#92)

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* Admin port change in gradle properties

* NM cloud scripts

* persistantFilePath change in config.yml

* config name change from production to nm-cloud

* adding plugin jacoco

* Change in gradle build for jacoco plugin

* SQL statemets for new schema change

* bug fix for max cov applicator (#97)

* fixing build issues

* adding sample test

* templates for Download

* Unit test (#24)

* unit test for requiremnet repository

* unit test for repository

* Repo (#25)

* removed paginated query to db

* interface to repo

* interface extending jpagenericrepository

* typed query

* override annotation

* rebasing with upstream

* Unit tests (#26)

* server repository

* unit test for download command

* removed unnecssary binding from test module

* interface repo name changed

* Proc client (#21)

* Get last app and supplier

* table name change

* changes in fetch app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* changes to fetch last app and supplier

* common code to fetch last app and supplier

* RP-173 adding base repos

* requested changes from review of pull#28

* nm-cloud-test config (#47)

* fix for sales bucket data

* nm-cloud-tesr

* db config for nm-cloud-test

* working code

* backward compatibility changes

* backward compatibility changes

* bug fixes

* select supplier for requirement

* disabling existing requirements before creating new

* bugfix for convertDaysToQuantity

* adding test cases

* bug fix

* bugfix for negative req when inv < max cov (#98)

setting proper values for projection state and enabled

* db config in nm cloud

* Filterdownload (#96)

* requirement by filter

* no reuirement selected

* filetr changes

* corrected query

* query corrected

* tset fix

* page numbber as 1

* filter download

* copy error

* fsn list

* page loop

* test fix

* test fix 1

* group as list in filter

* changes of code review

* code review changes

* group as list

* fetch in criteria query

* Filterdownload (#67)

* requirement by filter

* no reuirement selected

*…